### PR TITLE
Adds a comment specifying that tags must be printable ASCII.

### DIFF
--- a/stats/census.proto
+++ b/stats/census.proto
@@ -254,6 +254,7 @@ message IntervalAggregationDescriptor {
 }
 
 // A Tag: key-value pair.
+// Both strings must be printable ASCII.
 message Tag {
   string key = 1;
   string value = 2;


### PR DESCRIPTION
/cc @a-veitch 