### PR TITLE
Update comments on stats_context.proto to match the new encodings.

### DIFF
--- a/stats/stats_context.proto
+++ b/stats/stats_context.proto
@@ -16,20 +16,27 @@ package google.instrumentation;
 option java_package = "com.google.instrumentation.stats.proto";
 option java_outer_classname = "StatsContextProto";
 
-// Wire format of instrumentation stats (aka Census) tags.
+// StatsContext describes the encoding of stats context information (tags)
+// for passing across RPC's.
 message StatsContext {
-  // Encodes all stats tags (aka Census tags) to propagate over an RPC in a
-  // single byte vector.
+  // Tags are encoded as a single byte sequence. The format is:
+  // [tag_type key_len key_bytes value_len value_bytes]*
   //
-  // The format is:
-  //  num_tags [key_len key_bytes value_len value_bytes]*
-  //
-  // All implementations must honor these specs:
-  //  * The num_tags is represented using varint.
-  //  * The key/value lengths are represented using varint.
-  //  * All key/values must be US-ASCII.
-  //
-  // For details about varint, see:
-  //  https://developers.google.com/protocol-buffers/docs/encoding#varints
+  // Where:
+  //  * tag_type is one byte, and is used to describe the format of value_bytes.
+  //    In particular, the low 2 bits of this byte are used as follows:
+  //    00 (value 0): string (UTF-8) encoding
+  //    01 (value 1): integer (varint int64 encoding). See
+  //      https://developers.google.com/protocol-buffers/docs/encoding#varints
+  //      for documentation on the varint format.
+  //    10 (value 2): boolean format. In this case value_len should equal 1, and
+  //       the value_bytes will be a single byte containing either 0 (false) or
+  //       1 (true).
+  //    11 (value 3): byte sequence. Arbitrary uninterpreted bytes.
+  //  * The key_len and value_len fields are represented using a varint, with a
+  //    maximum value of 16383 bytes (this value is guaranteed to fit in at most
+  //    2 bytes). Zero length keys or values are not allowed.
+  //  * The value in key_bytes is a US-ASCII format string.
   bytes tags = 1;
 }
+


### PR DESCRIPTION
Refer to: https://docs.google.com/document/d/1z6ixVD1VDlDWyPE1o6KoquU_yNJ4E79PrvFiR6RD95s/edit#heading=h.za0m8gfrsbdh