### PR TITLE
Fix Maven parent.relativePath warning.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -19,6 +19,7 @@
     <groupId>com.google</groupId>
     <artifactId>google</artifactId>
     <version>5</version>
+    <relativePath></relativePath>
   </parent>
 
   <licenses>


### PR DESCRIPTION
Previously, when instrumentation-proto was used as a submodule of
instrumentation-java, Maven tried to get the parent pom.xml from the parent
directory.  This change clears the default so that Maven uses the central
repository instead.